### PR TITLE
adding some GRPO improvements from DeepSeek V3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 
 ## Latest 3 updates
 
+- DeepSeek V3.2 GRPO optimizations: Off-policy masking, Unbiased KL estimate
 - Nvidia LatentMoE from Nemotron 3 white paper
 - Qwen SAPO (Soft Adaptive Policy Optimization) loss implementation
-- Moonshot.ai's QK-Clip compatibility with Grouped attention variants (GQA, MQA)
 
 
 &nbsp;
@@ -53,6 +53,7 @@
 |:--------|:------------|
 | **Sparse MoE** | Classic auxiliary loss + z router loss |
 | **DeepSeek MoE** | Fine-grained + shared expert isolation + auxiliary loss-free load balancing |
+| **Nvidia LatentMoE** | latent/low rank compression + experts rebalancing |
 
 &nbsp;
 

--- a/llm_quest/alignment/rlhf_grpo/grpo_engine.py
+++ b/llm_quest/alignment/rlhf_grpo/grpo_engine.py
@@ -466,7 +466,7 @@ def log_probs_per_token_optimized(logits, inputs):
 def kl_div_per_token(policy_logprobs, reference_logprobs):
     """
     Compute the KL divergence per token between the policy and reference log probabilities.
-    Estimated with (Schulman, 2020) unbiased estimator, see:
+    Estimated with (Schulman, 2020) K3 unbiased estimator, see:
     https://github.com/casinca/LLM-quest/tree/master/llm_quest/alignment/rlhf_grpo#grpo
 
     Args:
@@ -531,7 +531,7 @@ def grpo_loss(
 
     # (PyTorch will broadcast the advantages anyway, unsqueezing to emphasize advantages aren't per tokens)
     # ie, each trajectory gets a single advantage.
-    advantages_broadcast = advantages.unsqueeze(-1)
+    advantages_broadcast = advantages.unsqueeze(-1)  # shape (B, 1)
 
     if variant == "sapo":
         return sapo_loss(policy_ratio, advantages_broadcast, loss_mask)

--- a/llm_quest/alignment/rlvr_grpo_reasoning/rlvr_engine.py
+++ b/llm_quest/alignment/rlvr_grpo_reasoning/rlvr_engine.py
@@ -10,8 +10,8 @@ from llm_quest.alignment.rlhf_grpo.grpo_engine import (
     grpo_loss,
     kl_div_per_token,
     log_probs_per_token,
-    z_scores,
     off_policy_seq_mask,
+    z_scores,
 )
 from llm_quest.generate import generate_batched_loop_kv_cache
 from llm_quest.utils import CheckpointEvaluator, ResponseExtractor
@@ -185,6 +185,7 @@ def rlvr_grpo_training_loop(
     min_clip_eps=0.2,
     max_clip_eps=0.2,
     beta=1.0,
+    unbiased_kl_estimate=False,
     evaluation=True,
     eval_freq=None,
     eval_batches=None,
@@ -221,6 +222,8 @@ def rlvr_grpo_training_loop(
         max_clip_eps (float): Upper clipping parameter ϵ for the policy ratio in the PPO-like clipped objective function
         beta (float): Coefficient 𝛽 for the KL divergence penalty term in the loss. Controls the
                     trade-off between maximizing reward and staying close to the reference policy.
+        unbiased_kl_estimate (bool, optional): Whether to use the Unbiased KL Estimate from the DeepSeek V3.2 paper.
+                    Defaults to False.
         evaluation (bool, optional): Whether to perform evaluation. Defaults to True.
         eval_freq (int, optional): Frequency (in training steps) at which to perform evaluation. Defaults to None.
         eval_batches (int, optional): Number of batches to evaluate on. If None, evaluates on the whole val_loader.
@@ -320,7 +323,11 @@ def rlvr_grpo_training_loop(
                 else:  # token level policy ratio
                     policy_ratio = torch.exp(policy_logprobs - old_logprobs)
 
-                kl_div = kl_div_per_token(policy_logprobs, reference_logprobs)  # (will be masked in the loss calc)
+                # KL divergence will be masked in the loss calc
+                if unbiased_kl_estimate:
+                    kl_div = kl_div_per_token(policy_logprobs, reference_logprobs, policy_ratio=policy_ratio)
+                else:
+                    kl_div = kl_div_per_token(policy_logprobs, reference_logprobs)
 
                 if off_policy_sequence_masking:
                     # KL div (as π_θ_old/π_θ) approximated with K1 estimator

--- a/llm_quest/alignment/rlvr_grpo_reasoning/rlvr_grpo_training.py
+++ b/llm_quest/alignment/rlvr_grpo_reasoning/rlvr_grpo_training.py
@@ -13,6 +13,7 @@ from llm_quest.alignment.rlvr_grpo_reasoning.rlvr_engine import (
 from llm_quest.dataset import ReasoningDataset
 from llm_quest.gpt.gpt_model import GPTModel
 
+# TODO rlvr_grpo_training.py needs to be reworked the same way as rpt_training_qwen3.py
 # --- hyperparameters ---
 gpt_config = config.gpt2_config_creator("gpt_m")
 model_device = config.auto_device


### PR DESCRIPTION
DeepSeek V3.2: https://arxiv.org/abs/2512.02556

Since DeepSeek Math recipe for GRPO and R1 Training, DeepSeek gives some interesting details on their Post RL training in the DeepSeek V3.2 paper. Without repeating too much what's already properly explained in the paper snippet below:

---

- 1 ) Unlike some OSS top labs (Qwen or AI2 in mind) they didn't drop the KL div for GRPO (the K3 estimator version) for V3.2 on the contrary, they went further and decided to scale it by the policy ratio.

<img width="1152" height="612" alt="image" src="https://github.com/user-attachments/assets/e5987195-3bd1-4ed8-9c47-4bd0cba44632" />

---

- 2 ) They also decided to hard mask sequences that they deem harmful for the model to learn (ie negative advantages accompanied with high KL). The reason is to combat the off policy drift induced by hybrid RL trainings with 1 framework for generationg and the other for training.
**NOTE** The 2nd point is only for completeness/fun: The reason for **Off-Policy Sequence Masking** isn't a problem here because the policy model for training is the exact same one rolling out/generating (the grpo training is from scratch and contained)

<img width="1087" height="1216" alt="image" src="https://github.com/user-attachments/assets/eb0f0657-f38e-4909-ab58-44a281905f10" />
